### PR TITLE
Variable maximum plan number

### DIFF
--- a/src/Client/BambooClient.php
+++ b/src/Client/BambooClient.php
@@ -59,11 +59,12 @@ class BambooClient extends AbstractBambooClient
     /**
      * Get a list of all plans.
      *
+     * @param integer $maxresult
      * @return Plan[]
      */
-    public function getPlanList(): array
+    public function getPlanList($maxresult = 25): array
     {
-        $response = $this->get('/rest/api/latest/plan.json');
+        $response = $this->get('/rest/api/latest/plan.json', ['max-results' => $maxresult]);
 
         if (200 !== (int) $response->getStatusCode()) {
             $this->throwRequestException('List of plans could not be requested.', $response);


### PR DESCRIPTION
I have added an optional max-result argument as Bamboo limit this by default at 25 plans. With this you can optionally give a number of plans you want to receive with the call.